### PR TITLE
Implement loading of schema classes not prefixed with YAML::PP::Schema

### DIFF
--- a/lib/YAML/PP/Schema.pm
+++ b/lib/YAML/PP/Schema.pm
@@ -58,7 +58,7 @@ sub bool_class { return $_[0]->{bool_class} }
 sub load_subschemas {
     my ($self, @schemas) = @_;
     for my $s (@schemas) {
-        my $class = ($s =~ m/^\:(.*)/) ? "$1" : "YAML::PP::Schema::" . $s;
+        my $class = ($s =~ m/^\:(.*)/) ? "$1" : "YAML::PP::Schema::$s";
         my $tags = $class->register(
             schema => $self,
         );

--- a/lib/YAML/PP/Schema.pm
+++ b/lib/YAML/PP/Schema.pm
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 package YAML::PP::Schema;
 use B;
+use Module::Load qw//;
 
 our $VERSION = '0.000'; # VERSION
 
@@ -58,7 +59,13 @@ sub bool_class { return $_[0]->{bool_class} }
 sub load_subschemas {
     my ($self, @schemas) = @_;
     for my $s (@schemas) {
-        my $class = ($s =~ m/^\:(.*)/) ? "$1" : "YAML::PP::Schema::$s";
+        my $class;
+        if ($s =~ m/^\:(.*)/) {
+          $class = "$1";
+          Module::Load::load $class;
+        } else {
+          $class = "YAML::PP::Schema::$s";
+        }
         my $tags = $class->register(
             schema => $self,
         );

--- a/lib/YAML/PP/Schema.pm
+++ b/lib/YAML/PP/Schema.pm
@@ -58,7 +58,7 @@ sub bool_class { return $_[0]->{bool_class} }
 sub load_subschemas {
     my ($self, @schemas) = @_;
     for my $s (@schemas) {
-        my $class = ($s =~ m/^\+(.*)/) ? "$1" : "YAML::PP::Schema::" . $s;
+        my $class = ($s =~ m/^\:(.*)/) ? "$1" : "YAML::PP::Schema::" . $s;
         my $tags = $class->register(
             schema => $self,
         );

--- a/lib/YAML/PP/Schema.pm
+++ b/lib/YAML/PP/Schema.pm
@@ -58,7 +58,7 @@ sub bool_class { return $_[0]->{bool_class} }
 sub load_subschemas {
     my ($self, @schemas) = @_;
     for my $s (@schemas) {
-        my $class = "YAML::PP::Schema::" . $s;
+        my $class = ($s =~ m/^\+(.*)/) ? "$1" : "YAML::PP::Schema::" . $s;
         my $tags = $class->register(
             schema => $self,
         );

--- a/t/41.custom.schema.t
+++ b/t/41.custom.schema.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use YAML::PP;
+
+use FindBin '$Bin';
+use lib "$Bin/lib";
+
+use MySchema;
+
+my $yp = YAML::PP->new(
+    schema => [qw/ +MySchema /],
+);
+
+my $data = {
+  o1 => (bless {}, 'Class1'),
+};
+
+my $yaml = $yp->dump_string($data);
+
+cmp_ok($yaml, 'eq', <<EOY, '$data serializes with the schema in t/lib/MySchema.pm');
+---
+o1: !Class1 ''
+EOY
+
+done_testing;

--- a/t/41.custom.schema.t
+++ b/t/41.custom.schema.t
@@ -10,7 +10,7 @@ use lib "$Bin/lib";
 use MySchema;
 
 my $yp = YAML::PP->new(
-    schema => [qw/ +MySchema /],
+    schema => [qw/ :MySchema /],
 );
 
 my $data = {

--- a/t/41.custom.schema.t
+++ b/t/41.custom.schema.t
@@ -7,8 +7,6 @@ use YAML::PP;
 use FindBin '$Bin';
 use lib "$Bin/lib";
 
-use MySchema;
-
 my $yp = YAML::PP->new(
     schema => [qw/ :MySchema /],
 );

--- a/t/lib/MySchema.pm
+++ b/t/lib/MySchema.pm
@@ -1,0 +1,27 @@
+package MySchema;
+  use base 'YAML::PP::Schema';
+  use strict;
+  use warnings;
+
+  sub new {
+    my ($class, %args) = @_;
+    my $self = bless {}, $class;
+    return $self;
+  }
+
+  sub register {
+    my ($self, %args) = @_;
+    my $schema = $args{schema};
+
+    $schema->add_representer(
+      class_equals => 'Class1',
+      code => sub {
+        my ($representer, $node) = @_;
+        # $node->{value} contains the object
+        $node->{tag} = '!Class1';
+        return 1;
+      },
+    );
+  }
+
+1;


### PR DESCRIPTION
Hi,

  As commented in https://github.com/pplu/cfn-perl/issues/23, I've had a shot at loading Schemas in custom namespaces. I've diverged from you initial proposal because it would have changed all the current loading of standard schemas (having to prepend them with ':'. I've used the '+' sign to signal that the class should be loaded without prepending `YAML::PP::Schema::` to it. Using the + sign remembered me of other modules (Catalyst?, that uses similar schemes for specifying custom namespaces for plugins).

   Hope this is helpful :)