### PR TITLE
fix manpage-has-bad-whatis-entry warning

### DIFF
--- a/lib/YAML/PP/Grammar.pm
+++ b/lib/YAML/PP/Grammar.pm
@@ -1102,7 +1102,7 @@ __END__
 
 =head1 NAME
 
-YAML::PP::Grammar
+YAML::PP::Grammar - YAML grammar
 
 =head1 GRAMMAR
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to YAML-PP.
We thought you might be interested in it too.

    Description: fix manpage-has-bad-whatis-entry warning
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2020-01-18
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libyaml-pp-perl/raw/master/debian/patches/pod-whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
